### PR TITLE
Rename algorithm webUI urls for consistency

### DIFF
--- a/src/components/job/ListJobs.vue
+++ b/src/components/job/ListJobs.vue
@@ -106,7 +106,7 @@
           </b-table-column>-->
 
           <b-table-column field="softwareName" :label="$t('algorithm')" sortable width="1000">
-            <router-link :to="`/software/${job.software}`">
+            <router-link :to="`/algorithm/${job.software}`">
               {{job.softwareName}}
             </router-link>
           </b-table-column>

--- a/src/components/navbar/CytomineNavbar.vue
+++ b/src/components/navbar/CytomineNavbar.vue
@@ -24,10 +24,10 @@
   </div>
   <div id="topMenu" class="navbar-menu" :class="{'is-active':openedTopMenu}">
     <div class="navbar-start">
-      <navbar-dropdown 
-      icon="fa-folder-open" 
-      v-if="this.nbActiveProjects > 0" 
-      :title="$t('workspace')" 
+      <navbar-dropdown
+      icon="fa-folder-open"
+      v-if="this.nbActiveProjects > 0"
+      :title="$t('workspace')"
       :listPathes="['/project/']">
         <navigation-tree />
       </navbar-dropdown>
@@ -43,7 +43,7 @@
         <i class="fas fa-hashtag"></i>
         {{ $t('ontologies') }}
       </router-link>
-      <router-link to="/software" class="navbar-item">
+      <router-link to="/algorithm" class="navbar-item">
         <i class="fas fa-code"></i>
         {{ $t('algorithms') }}
       </router-link>

--- a/src/components/project/configuration-panels/ProjectSoftwares.vue
+++ b/src/components/project/configuration-panels/ProjectSoftwares.vue
@@ -32,7 +32,7 @@
     >
       <template #default="{row: software}">
         <b-table-column field="name" :label="$t('name')" sortable width="100">
-          <router-link :to="`/software/${software.id}`">
+          <router-link :to="`/algorithm/${software.id}`">
             {{ software.fullName }}
           </router-link>
         </b-table-column>

--- a/src/components/software/ListSoftware.vue
+++ b/src/components/software/ListSoftware.vue
@@ -113,7 +113,7 @@
       >
         <template #default="{row: software}">
           <b-table-column field="name" :label="$t('name')" sortable width="250">
-            <router-link :to="`/software/${software.id}`">
+            <router-link :to="`/algorithm/${software.id}`">
               {{ software.fullName }}
             </router-link>
           </b-table-column>
@@ -139,7 +139,7 @@
           </b-table-column>
 
           <b-table-column label=" " centered width="150">
-            <router-link :to="`/software/${software.id}`" class="button is-small is-link">
+            <router-link :to="`/algorithm/${software.id}`" class="button is-small is-link">
               {{$t('button-open')}}
             </router-link>
           </b-table-column>

--- a/src/components/software/SoftwareInformation.vue
+++ b/src/components/software/SoftwareInformation.vue
@@ -18,7 +18,7 @@
     <div class="content-wrapper" v-if="!loading">
       <nav class="breadcrumb" aria-label="breadcrumbs">
         <ul>
-          <li><router-link :to="`/software`">{{$t('algorithms')}}</router-link></li>
+          <li><router-link :to="`/algorithm`">{{$t('algorithms')}}</router-link></li>
           <li class="is-active"><a href="#" aria-current="page">{{software.fullName}}</a></li>
         </ul>
       </nav>

--- a/src/routes.js
+++ b/src/routes.js
@@ -58,11 +58,11 @@ const routes = [
     component: ListOntologies
   },
   {
-    path: '/software',
+    path: '/algorithm',
     component: ListSoftware
   },
   {
-    path: '/software/:idSoftware',
+    path: '/algorithm/:idSoftware',
     component: SoftwareInformation
   },
   {
@@ -149,6 +149,7 @@ const routes = [
   {path: '/project', redirect: '/projects'},
   {path: '/explorer', redirect: '/'},
   {path: '/upload', redirect: '/storage'},
+  {path: '/software', redirect: '/algorithm'},
 
   {path: '/activity', redirect: '/'},
   {path: '/activity-:idProject-', redirect: '/project/:idProject/activity'},

--- a/src/routes.js
+++ b/src/routes.js
@@ -150,6 +150,7 @@ const routes = [
   {path: '/explorer', redirect: '/'},
   {path: '/upload', redirect: '/storage'},
   {path: '/software', redirect: '/algorithm'},
+  {path: '/software/:idSoftware', redirect: '/algorithm/:idSoftware'},
 
   {path: '/activity', redirect: '/'},
   {path: '/activity-:idProject-', redirect: '/project/:idProject/activity'},


### PR DESCRIPTION
As the term "Algorithm" is used everywhere in the webUI and as "software" term is deprecated in favor of "app" generally and "algorithm" specifically in the webUI, this PR renames the webUI urls to get information about Cytomine apps/Algorithms, for consistency.

This is fully backward compatible as there are redirections `/software -> /algorithm`.