### PR TITLE
Fix edit rectangle tool

### DIFF
--- a/src/components/viewer/interactions/ModifyInteraction.vue
+++ b/src/components/viewer/interactions/ModifyInteraction.vue
@@ -17,7 +17,9 @@
   <vl-interaction-modify
     v-if="activeEditTool === 'modify'"
     :source="selectSource"
+    ref="olModifyInteraction"
     :delete-condition="deleteCondition"
+    :insert-vertex-condition="insertVertexCondition"
     @modifystart="startEdit"
     @modifyend="endEdit"
   />
@@ -42,6 +44,7 @@
 import WKT from 'ol/format/WKT';
 import {Action} from '@/utils/annotation-utils.js';
 import {singleClick} from 'ol/events/condition';
+import {isRectangle} from '@/utils/geometry-utils';
 
 export default {
   name: 'modify-interaction',
@@ -80,6 +83,13 @@ export default {
     deleteCondition() {
       return function(mapBrowserEvent) {
         return mapBrowserEvent.originalEvent.ctrlKey && singleClick(mapBrowserEvent);
+      };
+    },
+    insertVertexCondition() {
+      return function() {
+        return !this.features_.getArray().every(function(feature) {
+          return isRectangle(feature.getGeometry());
+        });
       };
     }
   },

--- a/src/main.js
+++ b/src/main.js
@@ -65,11 +65,13 @@ import ZoomifySource from './vuelayers-suppl/zoomify-source';
 import RasterSource from './vuelayers-suppl/raster-source';
 import TranslateInteraction from './vuelayers-suppl/translate-interaction';
 import RotateInteraction from './vuelayers-suppl/rotate-interaction';
+import ModifyInteraction from './vuelayers-suppl/modify-interaction';
 Vue.use(VueLayers);
 Vue.use(ZoomifySource);
 Vue.use(RasterSource);
 Vue.use(TranslateInteraction);
 Vue.use(RotateInteraction);
+Vue.use(ModifyInteraction);
 
 import Chart from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';

--- a/src/utils/geometry-utils.js
+++ b/src/utils/geometry-utils.js
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2009-2020. Authors: see NOTICE file.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export function isRectangle(geometry) {
+  if (geometry.getLinearRingCount() !== 1 || geometry.getCoordinates()[0].length !== 5) {
+    return false;
+  }
+
+  const coordinates = geometry.getCoordinates(false)[0];
+  let prevX = coordinates[0][0];
+  let prevY = coordinates[0][1];
+  for (let i = 1; i <= 4; i++) {
+    let x = coordinates[i][0];
+    let y = coordinates[i][1];
+    let xChanged = (x !== prevX);
+    let yChanged = (y !== prevY);
+    if (xChanged === yChanged) {
+      return false;
+    }
+    prevX = x;
+    prevY = y;
+  }
+
+  return true;
+}

--- a/src/utils/geometry-utils.js
+++ b/src/utils/geometry-utils.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2009-2020. Authors: see NOTICE file.
+* Copyright (c) 2009-2022. Authors: see NOTICE file.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/vuelayers-suppl/modify-interaction/index.js
+++ b/src/vuelayers-suppl/modify-interaction/index.js
@@ -1,0 +1,37 @@
+/*
+* Copyright (c) 2009-2019. Authors: see NOTICE file.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { pick } from 'vuelayers/lib/util/minilo';
+import Interaction from './interaction.vue';
+
+function plugin (Vue, options = {}) {
+  if (plugin.installed) {
+    return;
+  }
+  plugin.installed = true;
+
+  options = pick(options, 'dataProjection');
+  Object.assign(Interaction, options);
+
+  Vue.component(Interaction.name, Interaction);
+}
+
+export default plugin;
+
+export {
+  Interaction,
+  plugin as install,
+};

--- a/src/vuelayers-suppl/modify-interaction/index.js
+++ b/src/vuelayers-suppl/modify-interaction/index.js
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2009-2019. Authors: see NOTICE file.
+* Copyright (c) 2009-2022. Authors: see NOTICE file.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/vuelayers-suppl/modify-interaction/interaction.vue
+++ b/src/vuelayers-suppl/modify-interaction/interaction.vue
@@ -1,0 +1,195 @@
+<script>
+import {altKeyOnly, always, primaryAction} from 'ol/events/condition';
+import ModifyInteraction from './modify';
+import interaction from 'vuelayers/lib/mixin/interaction';
+import stylesContainer from 'vuelayers/lib/mixin/styles-container';
+import {createStyle, defaultEditStyle} from 'vuelayers/lib/ol-ext/style';
+import {isCollection, isVectorSource} from 'vuelayers/lib/ol-ext/util';
+import observableFromOlEvent from 'vuelayers/lib/rx-ext/from-ol-event';
+import {hasInteraction} from 'vuelayers/lib/util/assert';
+import {isFunction, mapValues} from 'vuelayers/lib/util/minilo';
+import mergeDescriptors from 'vuelayers/lib/util/multi-merge-descriptors';
+import {makeWatchers} from 'vuelayers/lib/util/vue-helpers';
+
+/**
+ * @vueProps
+ */
+const props = {
+  /**
+   * Source or collection identifier from IdentityMap.
+   * @type {String}
+   */
+  source: {
+    type: String,
+    required: true,
+  },
+  /**
+   * A function that takes an `ol.MapBrowserEvent` and returns a boolean to indicate whether that event will be
+   * considered to add or move a vertex to the sketch. Default is `ol.events.condition.primaryAction`.
+   * @type {function|undefined}
+   */
+  condition: {
+    type: Function,
+    default: primaryAction,
+  },
+  /**
+   * A function that takes an `ol.MapBrowserEvent` and returns a boolean to indicate whether that event should be handled.
+   * By default, `ol.events.condition.singleClick` with `ol.events.condition.altKeyOnly` results in a vertex deletion.
+   * @type {function|undefined}
+   */
+  deleteCondition: {
+    type: Function,
+    default: altKeyOnly,
+  },
+  /**
+   * A function that takes an `ol.MapBrowserEvent` and returns a boolean to indicate whether a new vertex can be added
+   * to the sketch features. Default is `ol.events.condition.always`.
+   * @type {function|undefined}
+   */
+  insertVertexCondition: {
+    type: Function,
+    default: always,
+  },
+  /**
+   * Pixel tolerance for considering the pointer close enough to a segment or vertex for editing.
+   * @type {number}
+   */
+  pixelTolerance: {
+    type: Number,
+    default: 10,
+  },
+  /**
+   * Wrap the world horizontally on the sketch overlay.
+   * @type {boolean}
+   */
+  wrapX: {
+    type: Boolean,
+    default: false,
+  },
+};
+
+/**
+ * @vueMethods
+ */
+const methods = {
+  /**
+   * @return {Promise<Modify>}
+   * @protected
+   */
+  async createInteraction() {
+    let sourceIdent = this.makeIdent(this.source);
+    let source = await this.$identityMap.get(sourceIdent, this.$options.INSTANCE_PROMISE_POOL);
+
+    if (isFunction(source.getFeatures)) {
+      let features = source.getFeatures();
+      if (isCollection(features)) {
+        source = features;
+      }
+    }
+
+    console.log('coucou');
+
+    return new ModifyInteraction({
+      source: isVectorSource(source) ? source : undefined,
+      features: isCollection(source) ? source : undefined,
+      deleteCondition: this.deleteCondition,
+      insertVertexCondition: this.insertVertexCondition,
+      pixelTolerance: this.pixelTolerance,
+      style: this.createStyleFunc(),
+      wrapX: this.wrapX,
+    });
+  },
+  /**
+   * @return {function(feature: Feature): Style}
+   * @protected
+   */
+  getDefaultStyles() {
+    const defaultStyles = mapValues(defaultEditStyle(), styles => styles.map(createStyle));
+
+    return function __selectDefaultStyleFunc(feature) {
+      if (feature.getGeometry()) {
+        return defaultStyles[feature.getGeometry().getType()];
+      }
+    };
+  },
+  /**
+   * @returns {Object}
+   * @protected
+   */
+  getServices() {
+    return mergeDescriptors(
+      interaction.methods.getServices.call(this),
+      stylesContainer.methods.getServices.call(this),
+    );
+  },
+  /**
+   * @return {Interaction|undefined}
+   * @protected
+   */
+  getStyleTarget() {
+    return this.$interaction;
+  },
+  /**
+   * @return {void}
+   * @protected
+   */
+  mount() {
+    interaction.methods.mount.call(this);
+  },
+  /**
+   * @return {void}
+   * @protected
+   */
+  unmount() {
+    interaction.methods.unmount.call(this);
+  },
+  /**
+   * @param {Array<{style: Style, condition: (function|boolean|undefined)}>|function(feature: Feature): Style|Vue|undefined} styles
+   * @return {void}
+   * @protected
+   */
+  setStyle(styles) {
+    if (styles !== this._styles) {
+      this._styles = styles;
+      this.scheduleRefresh();
+    }
+  },
+  /**
+   * @return {void}
+   * @protected
+   */
+  subscribeAll() {
+    subscribeToInteractionChanges.call(this);
+  },
+};
+
+const watch = makeWatchers(['source'], () => function () {
+  this.scheduleRecreate();
+});
+
+/**
+ * @vueProto
+ * @alias module:modify-interaction/interaction
+ * @title vl-interaction-modify
+ */
+export default {
+  name: 'vl-interaction-modify',
+  mixins: [interaction, stylesContainer],
+  props,
+  methods,
+  watch,
+};
+
+/**
+ * @private
+ */
+function subscribeToInteractionChanges() {
+  hasInteraction(this);
+
+  const modifyEvents = observableFromOlEvent(this.$interaction, ['modifystart', 'modifyend']);
+  this.subscribeTo(modifyEvents, evt => {
+    ++this.rev;
+    this.$emit(evt.type, evt);
+  });
+}
+</script>

--- a/src/vuelayers-suppl/modify-interaction/interaction.vue
+++ b/src/vuelayers-suppl/modify-interaction/interaction.vue
@@ -87,8 +87,6 @@ const methods = {
       }
     }
 
-    console.log('coucou');
-
     return new ModifyInteraction({
       source: isVectorSource(source) ? source : undefined,
       features: isCollection(source) ? source : undefined,

--- a/src/vuelayers-suppl/modify-interaction/modify.js
+++ b/src/vuelayers-suppl/modify-interaction/modify.js
@@ -1,0 +1,185 @@
+import ModifyInteractionBase from 'ol/interaction/Modify';
+import GeometryType from 'ol/geom/GeometryType';
+import {equals as coordinatesEqual, distance as coordinateDistance, closestOnSegment} from 'ol/coordinate';
+import {getUid} from 'ol/util';
+import {boundingExtent} from 'ol/extent';
+
+/**
+ * @param {SegmentData} a The first segment data.
+ * @param {SegmentData} b The second segment data.
+ * @return {number} The difference in indexes.
+ */
+function compareIndexes(a, b) {
+  return a.index - b.index;
+}
+
+/**
+ * Returns the point closest to a given line segment.
+ *
+ * @param {import("ol/coordinate").Coordinate} pointCoordinates The point to which a closest point
+ *        should be found.
+ * @param {SegmentData} segmentData The object describing the line
+ *        segment which should contain the closest point.
+ * @return {import("ol/coordinate").Coordinate} The point closest to the specified line segment.
+ */
+function closestOnSegmentData(pointCoordinates, segmentData) {
+  const geometry = segmentData.geometry;
+
+  if (geometry.getType() === GeometryType.CIRCLE &&
+    segmentData.index === 1) {
+    return geometry.getClosestPoint(pointCoordinates);
+  }
+  return closestOnSegment(pointCoordinates, segmentData.segment);
+}
+
+
+export default class ModifyInteraction extends ModifyInteractionBase {
+  handleDragEvent(evt) {
+    this.ignoreNextSingleClick_ = false;
+    this.willModifyFeatures_(evt);
+
+    const vertex = evt.coordinate;
+    for (let i = 0, ii = this.dragSegments_.length; i < ii; ++i) {
+      const dragSegment = this.dragSegments_[i];
+      const segmentData = dragSegment[0];
+      const depth = segmentData.depth;
+      const geometry = segmentData.geometry;
+      let coordinates;
+      const segment = segmentData.segment;
+      const index = dragSegment[1];
+
+      while (vertex.length < geometry.getStride()) {
+        vertex.push(segment[index][vertex.length]);
+      }
+
+      switch (geometry.getType()) {
+        case GeometryType.POINT:
+          coordinates = vertex;
+          segment[0] = segment[1] = vertex;
+          break;
+        case GeometryType.MULTI_POINT:
+          coordinates = geometry.getCoordinates();
+          coordinates[segmentData.index] = vertex;
+          segment[0] = segment[1] = vertex;
+          break;
+        case GeometryType.LINE_STRING:
+          coordinates = geometry.getCoordinates();
+          coordinates[segmentData.index + index] = vertex;
+          segment[index] = vertex;
+          break;
+        case GeometryType.MULTI_LINE_STRING:
+          coordinates = geometry.getCoordinates();
+          coordinates[depth[0]][segmentData.index + index] = vertex;
+          segment[index] = vertex;
+          break;
+        case GeometryType.POLYGON:
+          coordinates = geometry.getCoordinates();
+          coordinates[depth[0]][segmentData.index + index] = vertex;
+          segment[index] = vertex;
+          break;
+        case GeometryType.MULTI_POLYGON:
+          coordinates = geometry.getCoordinates();
+          coordinates[depth[1]][depth[0]][segmentData.index + index] = vertex;
+          segment[index] = vertex;
+          break;
+        case GeometryType.CIRCLE:
+          segment[0] = segment[1] = vertex;
+          if (segmentData.index === 1) {
+            this.changingFeature_ = true;
+            geometry.setCenter(vertex);
+            this.changingFeature_ = false;
+          }
+          else { // We're dragging the circle's circumference:
+            this.changingFeature_ = true;
+            geometry.setRadius(coordinateDistance(geometry.getCenter(), vertex));
+            this.changingFeature_ = false;
+          }
+          break;
+        default:
+        // pass
+      }
+
+      if (coordinates) {
+        this.setGeometryCoordinates_(geometry, coordinates);
+      }
+    }
+    this.createOrUpdateVertexFeature_(vertex);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(evt) {
+    if (!this.condition_(evt)) {
+      return false;
+    }
+    this.handlePointerAtPixel_(evt.pixel, evt.map);
+    const pixelCoordinate = evt.map.getCoordinateFromPixel(evt.pixel);
+    this.dragSegments_.length = 0;
+    this.modified_ = false;
+    const vertexFeature = this.vertexFeature_;
+    if (vertexFeature) {
+      const insertVertices = [];
+      const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
+      const vertex = geometry.getCoordinates();
+      const vertexExtent = boundingExtent([vertex]);
+      const segmentDataMatches = this.rBush_.getInExtent(vertexExtent);
+      const componentSegments = {};
+      segmentDataMatches.sort(compareIndexes);
+      for (let i = 0, ii = segmentDataMatches.length; i < ii; ++i) {
+        const segmentDataMatch = segmentDataMatches[i];
+        const segment = segmentDataMatch.segment;
+        let uid = getUid(segmentDataMatch.feature);
+        const depth = segmentDataMatch.depth;
+        if (depth) {
+          uid += '-' + depth.join('-'); // separate feature components
+        }
+        if (!componentSegments[uid]) {
+          componentSegments[uid] = new Array(2);
+        }
+        if (segmentDataMatch.geometry.getType() === GeometryType.CIRCLE &&
+          segmentDataMatch.index === 1) {
+
+          const closestVertex = closestOnSegmentData(pixelCoordinate, segmentDataMatch);
+          if (coordinatesEqual(closestVertex, vertex) && !componentSegments[uid][0]) {
+            this.dragSegments_.push([segmentDataMatch, 0]);
+            componentSegments[uid][0] = segmentDataMatch;
+          }
+        }
+        else if (coordinatesEqual(segment[0], vertex) &&
+          !componentSegments[uid][0]) {
+          this.dragSegments_.push([segmentDataMatch, 0]);
+          componentSegments[uid][0] = segmentDataMatch;
+        }
+        else if (coordinatesEqual(segment[1], vertex) &&
+          !componentSegments[uid][1]) {
+
+          // prevent dragging closed linestrings by the connecting node
+          if ((segmentDataMatch.geometry.getType() ===
+            GeometryType.LINE_STRING ||
+            segmentDataMatch.geometry.getType() ===
+            GeometryType.MULTI_LINE_STRING) &&
+            componentSegments[uid][0] &&
+            componentSegments[uid][0].index === 0) {
+            continue;
+          }
+
+          this.dragSegments_.push([segmentDataMatch, 1]);
+          componentSegments[uid][1] = segmentDataMatch;
+        }
+        else if (this.insertVertexCondition_(evt) && getUid(segment) in this.vertexSegments_ &&
+          (!componentSegments[uid][0] && !componentSegments[uid][1])) {
+          insertVertices.push([segmentDataMatch, vertex]);
+        }
+      }
+      if (insertVertices.length) {
+        this.willModifyFeatures_(evt);
+      }
+      for (let j = insertVertices.length - 1; j >= 0; --j) {
+        this.insertVertex_.apply(this, insertVertices[j]);
+      }
+    }
+    return !!this.vertexFeature_;
+  }
+}
+


### PR DESCRIPTION
There is a Rectangle tool in the webUI. Internally, the rectangle is stored as a polygon. When the user wants to modify its annotation, the Edit tool considers the annotation as a polygon. A modification with the Edit tool transforms the rectangle in an arbitrary polygon. It is nearly impossible to keep a true rectangle.

This PR updates to modify logic at low-level as it overrides OpenLayers implementation, in `modify.js`. To identify what has been patched to OpenLayers implementation, see commit e2af0ef7ddba99af4df71e3c9fee9ea41026090d

It is particularly useful to edit ROI, and in computer vision field, which nearly only uses bounding boxes as annotations.

It has been intensively tested and used in production since October 2020.