### PR TITLE
Add rescale annotation tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "npm-font-open-sans": "^1.1.0",
     "ol": "^5.3.1",
     "ol-rotate-feature": "^2.0.1",
+    "ol-rescale-feature": "^1.0.0",
     "sl-vue-tree": "1.8.3",
     "v-click-outside-x": "^4.0.1",
     "v-tooltip": "^2.0.0-rc.33",

--- a/src/components/project/configuration-panels/CustomUIProject.vue
+++ b/src/components/project/configuration-panels/CustomUIProject.vue
@@ -157,6 +157,7 @@ export default {
             {key: 'project-tools-fill', label: 'fill', icon: 'fas fa-fill', parentConfiguration: 'project-tools-main'},
             {key: 'project-tools-edit', label: 'modify', icon: 'fas fa-edit', parentConfiguration: 'project-tools-main'},
             {key: 'project-tools-move', label: 'move', icon: 'fas fa-arrows-alt', parentConfiguration: 'project-tools-main'},
+            {key: 'project-tools-resize', label: 'rescale', icon: 'fas fa-expand', parentConfiguration: 'project-tools-main'},
             {key: 'project-tools-rotate', label: 'rotate', icon: 'fas fa-sync-alt', parentConfiguration: 'project-tools-main'},
             {key: 'project-tools-delete', label: 'delete', icon: 'fas fa-trash-alt', parentConfiguration: 'project-tools-main'},
             {key: 'project-tools-copy-paste', label: 'copy-paste', icon: 'fas fa-copy', parentConfiguration: 'project-tools-main'},

--- a/src/components/viewer/DrawTools.vue
+++ b/src/components/viewer/DrawTools.vue
@@ -271,6 +271,17 @@
     </button>
 
     <button
+        v-if="isToolDisplayed('resize')"
+        :disabled="isToolDisabled('resize')"
+        v-tooltip="$t('resize')"
+        class="button"
+        :class="{'is-selected': activeEditTool === 'rescale'}"
+        @click="activateEditTool('rescale')"
+    >
+      <span class="icon is-small"><i class="fas fa-expand"></i></span>
+    </button>
+
+    <button
       v-if="isToolDisplayed('rotate')"
       :disabled="isToolDisabled('rotate')"
       v-tooltip="$t('rotate')"
@@ -941,6 +952,11 @@ export default {
         case 'tool-move':
           if (this.isToolDisplayed('move') && !this.isToolDisabled('move')) {
             this.activateEditTool('translate');
+          }
+          return;
+        case 'tool-rescale':
+          if (this.isToolDisplayed('resize') && !this.isToolDisabled('resize')) {
+            this.activateEditTool('rescale');
           }
           return;
         case 'tool-rotate':

--- a/src/components/viewer/interactions/ModifyInteraction.vue
+++ b/src/components/viewer/interactions/ModifyInteraction.vue
@@ -29,6 +29,13 @@
     @translateend="endEdit"
   />
 
+  <vl-interaction-rescale
+    v-if="activeEditTool === 'rescale'"
+    :source="selectSource"
+    @rescalestart="startEdit"
+    @rescaleend="endEdit"
+  />
+
   <vl-interaction-rotate
     v-if="activeEditTool === 'rotate'"
     :source="selectSource"

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -72,6 +72,7 @@ display-annot-details,Display details of currently selected annotation,Afficher 
 fill,Fill,Remplir,Rellenar
 modify,Modify,Modifier,Modificar
 move,Move,Déplacer,Mover
+resize,Resize,Redimensionner
 rotate,Rotate,Pivoter,Girar
 delete,Delete,Supprimer,Eliminar
 rename,Rename,Renommer,Renombrar
@@ -885,7 +886,8 @@ shortcut-viewer-tool-correct-add,Correct annotation by adding a freehand area,Co
 shortcut-viewer-tool-correct-remove,Correct annotation by removing a freehand area,Corriger l'annotation en lui soustrayant un polygone à main levée,Correjir anotación eliminando un área a mano alzada
 shortcut-viewer-tool-modify,Modify annotation,Modifier l'annotation,Modificar anotación
 shortcut-viewer-tool-modify-delete-vertex,Delete a vertex with the modify tool,Supprimer un sommêt avec l'outil de modification,Eliminar un vértice con la herramienta de modificación
-shortcut-viewer-tool-move,Move annotation,Déplacer l'annotation,Mover anotación
+shortcut-viewer-tool-move,Move annotation,Déplacer l'annotation
+shortcut-viewer-tool-rescale,Rescale annotation,Redimensionner l'annotation,Mover anotación
 shortcut-viewer-tool-rotate,Rotate annotation,Pivoter l'annotation,Rotar anotación
 shortcut-viewer-toggle-information,Toggle information panel,Afficher/Masquer le panneau d'information,Alternar panel de información
 shortcut-viewer-toggle-zoom,Toggle zoom panel,Afficher/Masquer le panneau de zoom,Alternar panel de zoom

--- a/src/main.js
+++ b/src/main.js
@@ -65,11 +65,13 @@ import ZoomifySource from './vuelayers-suppl/zoomify-source';
 import RasterSource from './vuelayers-suppl/raster-source';
 import TranslateInteraction from './vuelayers-suppl/translate-interaction';
 import RotateInteraction from './vuelayers-suppl/rotate-interaction';
+import RescaleInteraction from './vuelayers-suppl/rescale-interaction';
 Vue.use(VueLayers);
 Vue.use(ZoomifySource);
 Vue.use(RasterSource);
 Vue.use(TranslateInteraction);
 Vue.use(RotateInteraction);
+Vue.use(RescaleInteraction);
 
 import Chart from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';

--- a/src/utils/shortcuts.js
+++ b/src/utils/shortcuts.js
@@ -58,7 +58,7 @@ export default Object.freeze({
   'viewer-tool-correct-remove': ['alt', 'shift', 'c'],
   'viewer-tool-modify': ['m'],
   'viewer-tool-modify-delete-vertex': ['ctrl', 'click'], // Handled by Openlayers
-  // 'viewer-tool-rescale': ['shift', 'm'],
+  'viewer-tool-rescale': ['shift', 'm'],
   'viewer-tool-move': ['t'],
   'viewer-tool-rotate': ['shift', 't'],
   'viewer-tool-delete': ['del'],

--- a/src/vuelayers-suppl/rescale-interaction/index.js
+++ b/src/vuelayers-suppl/rescale-interaction/index.js
@@ -1,0 +1,37 @@
+/*
+* Copyright (c) 2009-2022. Authors: see NOTICE file.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { pick } from 'vuelayers/lib/util/minilo';
+import Interaction from './interaction.vue';
+
+function plugin (Vue, options = {}) {
+  if (plugin.installed) {
+    return;
+  }
+  plugin.installed = true;
+
+  options = pick(options, 'dataProjection');
+  Object.assign(Interaction, options);
+
+  Vue.component(Interaction.name, Interaction);
+}
+
+export default plugin;
+
+export {
+  Interaction,
+  plugin as install,
+};

--- a/src/vuelayers-suppl/rescale-interaction/interaction.vue
+++ b/src/vuelayers-suppl/rescale-interaction/interaction.vue
@@ -1,0 +1,168 @@
+<!-- Copyright (c) 2009-2022. Authors: see NOTICE file.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.-->
+
+<script>
+/** @module rotate-interaction/interaction */
+import RescaleFeatureInteraction from 'ol-rescale-feature';
+import observableFromOlEvent from 'vuelayers/lib/rx-ext/from-ol-event';
+import interaction from 'vuelayers/lib/mixin/interaction';
+import stylesContainer from 'vuelayers/lib/mixin/styles-container';
+import { defaultEditStyle, createStyle } from 'vuelayers/lib/ol-ext/style';
+import { isCollection, isVectorSource } from 'vuelayers/lib/ol-ext/util';
+import { mapValues, isFunction } from 'vuelayers/lib/util/minilo';
+import mergeDescriptors from 'vuelayers/lib/util/multi-merge-descriptors';
+import { hasInteraction } from 'vuelayers/lib/util/assert';
+import { makeWatchers } from 'vuelayers/lib/util/vue-helpers';
+
+/**
+ * @vueProps
+ */
+const props = {
+  /**
+   * Source or collection identifier from IdentityMap.
+   * @type {String}
+   */
+  source: {
+    type: String,
+    required: true,
+  },
+  /**
+   * Initial scale factor, applied for features already added to collection.
+   * @type {number}
+   */
+  factor: {
+    type: Number,
+    default: 1,
+  },
+};
+
+/**
+ * @vueMethods
+ */
+const methods = {
+  /**
+   * @return {Promise<ol.interaction.Rescale>}
+   * @protected
+   */
+  async createInteraction () {
+    let sourceIdent = this.makeIdent(this.source);
+    let source = await this.$identityMap.get(sourceIdent, this.$options.INSTANCE_PROMISE_POOL);
+    if (isFunction(source.getFeatures)) {
+      let features = source.getFeatures();
+      if (isCollection(features)) {
+        source = features;
+      }
+    }
+    return new RescaleFeatureInteraction({
+      source: isVectorSource(source) ? source : undefined,
+      features: isCollection(source) ? source : undefined,
+      deleteCondition: this.deleteCondition,
+      insertVertexCondition: this.insertVertexCondition,
+      pixelTolerance: this.pixelTolerance,
+      style: this.createStyleFunc(),
+      wrapX: this.wrapX,
+    });
+  },
+  /**
+   * @return {ol.StyleFunction}
+   * @protected
+   */
+  getDefaultStyles () {
+    const defaultStyles = mapValues(defaultEditStyle(), styles => styles.map(createStyle));
+    return function __selectDefaultStyleFunc (feature) {
+      if (feature.getGeometry()) {
+        return defaultStyles[feature.getGeometry().getType()];
+      }
+    };
+  },
+  /**
+   * @returns {Object}
+   * @protected
+   */
+  getServices () {
+    return mergeDescriptors(
+      interaction.methods.getServices.call(this),
+      stylesContainer.methods.getServices.call(this),
+    );
+  },
+  /**
+   * @return {ol.interaction.Interaction|undefined}
+   * @protected
+   */
+  getStyleTarget () {
+    return this.$interaction;
+  },
+  /**
+   * @return {void}
+   * @protected
+   */
+  mount () {
+    interaction.methods.mount.call(this);
+  },
+  /**
+   * @return {void}
+   * @protected
+   */
+  unmount () {
+    interaction.methods.unmount.call(this);
+  },
+  /**
+   * @return {void}
+   * @protected
+   */
+  subscribeAll () {
+    subscribeToInteractionChanges.call(this);
+  },
+  /**
+   * @param {Array<{style: ol.style.Style, condition: (function|boolean|undefined)}>|ol.StyleFunction|Vue|undefined} styles
+   * @return {void}
+   * @protected
+   */
+  setStyle (styles) {
+    if (styles !== this._styles) {
+      this._styles = styles;
+      this.scheduleRefresh();
+    }
+  },
+};
+
+const watch = makeWatchers(['source'], () => function () {
+  this.scheduleRecreate();
+});
+
+/**
+ * @vueProto
+ * @alias module:rescale-interaction/interaction
+ * @title vl-interaction-rescale
+ */
+export default {
+  name: 'vl-interaction-rescale',
+  mixins: [interaction, stylesContainer],
+  props,
+  methods,
+  watch,
+};
+
+/**
+ * @private
+ */
+function subscribeToInteractionChanges () {
+  hasInteraction(this);
+  const rescaleEvents = observableFromOlEvent(this.$interaction, ['rescalestart', 'rescaleend']);
+  this.subscribeTo(rescaleEvents, evt => {
+    ++this.rev;
+    this.$emit(evt.type, evt);
+  });
+}
+</script>


### PR DESCRIPTION
This PR add a Rescale annotation tool. To be exact, the Rescale tool was in Cytomine-Web-UI V1, but has been removed due to lack of support by OpenLayers in webUI v2.x

The Rescale tool is particularly useful for computer vision datasets, or after a copy/paste annotation.

Behind the scenes, it uses [`ol-rescale-feature` lib](https://github.com/urubens/ol-rescale-feature) that I've written based on `ol-rotate-feature` that is used for Rotation tool.

It has been used in production for several months without any issue.
