### PR TITLE
Fix list filters logic for projects, images and jobs

### DIFF
--- a/src/components/image/ImageDetails.vue
+++ b/src/components/image/ImageDetails.vue
@@ -344,7 +344,7 @@ export default {
       return this.blindMode ? this.image.blindedName : this.image.instanceFilename;
     },
     vendor() {
-      return vendorFromMime(this.image.mime);
+      return vendorFromMime(this.image.contentType);
     }
   },
   methods: {

--- a/src/components/image/ListImages.vue
+++ b/src/components/image/ListImages.vue
@@ -159,6 +159,7 @@
 
       <cytomine-table
         :collection="imageCollection"
+        :is-empty="nbEmptyFilters > 0"
         :currentPage.sync="currentPage"
         :perPage.sync="perPage"
         :openedDetailed.sync="openedDetails"
@@ -378,6 +379,9 @@ export default {
 
     nbActiveFilters() {
       return this.$store.getters[this.storeModule + '/nbActiveFilters'];
+    },
+    nbEmptyFilters() {
+      return this.$store.getters[this.storeModule + '/nbEmptyFilters'];
     },
 
     currentPage: sync('currentPage', storeOptions),

--- a/src/components/job/ListJobs.vue
+++ b/src/components/job/ListJobs.vue
@@ -90,6 +90,7 @@
 
       <cytomine-table
         :collection="jobCollection"
+        :is-empty="nbEmptyFilters > 0"
         :currentPage.sync="currentPage"
         :perPage.sync="perPage"
         :openedDetailed.sync="openedDetails"
@@ -221,6 +222,10 @@ export default {
     selectedDate: sync('executionDate', storeOptions),
     selectedStatus: localSyncMultiselectFilter('statuses', 'availableStatus'),
     selectedFavorites: localSyncMultiselectFilter('favorites', 'availableFavorites'),
+
+    nbEmptyFilters() {
+      return this.$store.getters[this.storeModule + '/nbEmptyFilters'];
+    },
 
     jobCollection() {
       let collection = new JobCollection({

--- a/src/components/project/ListProjects.vue
+++ b/src/components/project/ListProjects.vue
@@ -135,6 +135,7 @@
 
       <cytomine-table
         :collection="projectCollection"
+        :is-empty="nbEmptyFilters > 0"
         class="table-projects"
         :currentPage.sync="currentPage"
         :perPage.sync="perPage"
@@ -305,6 +306,9 @@ export default {
 
     nbActiveFilters() {
       return this.$store.getters['listProjects/nbActiveFilters'];
+    },
+    nbEmptyFilters() {
+      return this.$store.getters['listProjects/nbEmptyFilters'];
     },
 
     selectedOntologiesIds() {

--- a/src/components/project/configuration-panels/ProjectMembers.vue
+++ b/src/components/project/configuration-panels/ProjectMembers.vue
@@ -47,6 +47,7 @@
 
     <cytomine-table
       :collection="MemberCollection"
+      :is-empty="this.selectedRoles.length === 0"
       :currentPage.sync="currentPage"
       :perPage.sync="perPage"
       :sort.sync="sortField"
@@ -180,7 +181,6 @@ export default {
 
       return collection;
     },
-
 
     exportURL() {
       // TODO in core: should export only the filtered users

--- a/src/components/utils/CytomineTable.vue
+++ b/src/components/utils/CytomineTable.vue
@@ -85,7 +85,8 @@ export default {
   name: 'cytomine-table',
   props: {
     collection: Object,
-    perPageOptions: {type: Array, default: () => [10, 25, 50, 100]},
+    isEmpty: {type: Boolean, default: false},
+    perPageOptions: {type: Array, default: () => [5, 10, 25, 50, 100]},
     perPage: {type: Number, default: 25},
     currentPage: {type: Number, default: 1},
     detailed: {type: Boolean, default: true},
@@ -167,7 +168,14 @@ export default {
       }
 
       try {
-        let data = await this.internalCollection.fetchPage(this.internalCurrentPage - 1);
+        let data = {array: [], totalNbItems: 0};
+        if (this.isEmpty) {
+          this.internalCurrentPage = 1;
+        }
+        else {
+          data = await this.internalCollection.fetchPage(this.internalCurrentPage - 1);
+        }
+
         this.data = data.array;
         this.total = data.totalNbItems;
 

--- a/src/store/modules/list-projects.js
+++ b/src/store/modules/list-projects.js
@@ -20,9 +20,9 @@ function getDefaultState() {
 
     filtersOpened: false,
     filters: {
-      selectedOntologies: [],
-      selectedRoles: [],
-      selectedTags: [],
+      selectedOntologies: null,
+      selectedRoles: null,
+      selectedTags: null,
       boundsMembers: null,
       boundsImages: null,
       boundsUserAnnotations: null,
@@ -83,7 +83,11 @@ export default {
 
   getters: {
     nbActiveFilters: state => {
-      return Object.values(state.filters).filter(val => val && val.length > 0).length; // count the number of not null values
+      return Object.values(state.filters).filter(val => val).length; // count the number of not null values
+    },
+
+    nbEmptyFilters: state => {
+      return Object.values(state.filters).filter(val => val && val.length === 0).length;
     }
   }
 };

--- a/src/store/modules/project_modules/list-images.js
+++ b/src/store/modules/project_modules/list-images.js
@@ -23,11 +23,11 @@ export default {
 
       filtersOpened: false,
       filters: {
-        formats: [],
-        vendors: [],
-        selectedTags: [],
-        magnifications: [],
-        resolutions: [],
+        formats: null,
+        vendors: null,
+        selectedTags: null,
+        magnifications: null,
+        resolutions: null,
         boundsWidth: null,
         boundsHeight: null,
         boundsUserAnnotations: null,
@@ -79,7 +79,11 @@ export default {
 
   getters: {
     nbActiveFilters: state => {
-      return Object.values(state.filters).filter(val => val && val.length > 0).length; // count the number of not null values
+      return Object.values(state.filters).filter(val => val).length; // count the number of not null values
+    },
+
+    nbEmptyFilters: state => {
+      return Object.values(state.filters).filter(val => val && val.length === 0).length;
     }
   }
 };

--- a/src/store/modules/project_modules/list-jobs.js
+++ b/src/store/modules/project_modules/list-jobs.js
@@ -20,10 +20,10 @@ export default {
   state() {
     return {
       filters: {
-        softwares: [],
-        launchers: [],
-        statuses: [],
-        favorites: []
+        softwares: null,
+        launchers: null,
+        statuses: null,
+        favorites: null
       },
       executionDate: null,
 
@@ -62,6 +62,16 @@ export default {
 
     setOpenedDetails(state, value) {
       state.openedDetails = value;
+    }
+  },
+
+  getters: {
+    nbActiveFilters: state => {
+      return Object.values(state.filters).filter(val => val).length; // count the number of not null values
+    },
+
+    nbEmptyFilters: state => {
+      return Object.values(state.filters).filter(val => val && val.length === 0).length;
     }
   }
 };


### PR DESCRIPTION
The logic of filters for listing of projects, images and jobs is weird and inconsistent with other filters, such as the ones in the Annotation tab.

By default, nothing is selected in the filter, and it is considered as if everything was selected. Thus, clicking on "Select all" in the dropdown, effectively select everything in the dropdown, but nothing change in the list, as it was considered as if everything was selected. Then, clicking again on "Select all" deselects everything in the dropdown, but nothing change in the list, as an empty list is considered as if everything was selected.

This is counter-intuitive. This PR fixes this behavior, and re-uses the logic of the Annotation tab. That is:
* If filter is empty, it is stored as an empty list `[]`. Backend is not fetched and the list results in replaced by a no-result message.
* If some values are selected, the list is stored in the store and backend is fetched (no changes here)
* If all values are selected, it is stored as **`null`**. The backend is fetched, but the concerned filter is not sent in the request, as `null` means all selected.

By default, the filters have thus to be set to `null` (all selected).

By the way, it fixes the vendor and format filters in the image list that are not working (probably a change with the multidimensional features, as mime type is now stored a slice level).

It has been tested and used in production for 2 years on ULiege edition.