### PR TITLE
Refactor programmatic annotation selection

### DIFF
--- a/src/components/annotations/AnnotationPreview.vue
+++ b/src/components/annotations/AnnotationPreview.vue
@@ -21,7 +21,7 @@
 > <!-- autoHide leads to erratic behaviour when adding/showing DOM elements => handle display of popover manually -->
 
   <div class="annot-preview">
-    <div :style="styleAnnotDetails" @click.self="viewAnnot()">
+    <div :style="styleAnnotDetails" @click.self="viewAnnot(sameViewOnClick)">
       <button class="button is-small" @click="opened = !opened" ref="previewButton">
         <i :class="['fas', opened ? 'fa-minus' : 'fa-plus']"></i>
       </button>
@@ -72,7 +72,8 @@ export default {
     images: Array,
     tracks: Array,
     showImageInfo: {type: Boolean, default: true},
-    showSliceInfo: {type: Boolean, default: false}
+    showSliceInfo: {type: Boolean, default: false},
+    sameViewOnClick: {type: Boolean, default: false}
   },
   components: {AnnotationDetails},
   data() {
@@ -97,8 +98,8 @@ export default {
     }
   },
   methods: {
-    viewAnnot() {
-      this.$emit('select', this.annot);
+    viewAnnot(trySameView=false) {
+      this.$emit('select', {annot: this.annot, options:{trySameView}});
     },
     close(event) {
       if(!this.opened) {

--- a/src/components/annotations/AnnotationPreview.vue
+++ b/src/components/annotations/AnnotationPreview.vue
@@ -48,6 +48,7 @@
       @updateTerms="$emit('updateTermsOrTracks')"
       @updateTracks="$emit('updateTermsOrTracks')"
       @updateProperties="$emit('updateProperties')"
+      @select="$emit('select', $event)"
       @centerView="$emit('centerView')"
       @deletion="handleDeletion"
       v-if="opened"
@@ -97,7 +98,7 @@ export default {
   },
   methods: {
     viewAnnot() {
-      this.$emit('selectAnnotation');
+      this.$emit('select', this.annot);
     },
     close(event) {
       if(!this.opened) {

--- a/src/components/annotations/ListAnnotations.vue
+++ b/src/components/annotations/ListAnnotations.vue
@@ -572,8 +572,8 @@ export default {
     }
   },
   methods: {
-    viewAnnot(annot) {
-      this.$router.push(`/project/${annot.project}/image/${annot.image}/annotation/${annot.id}`);
+    viewAnnot({annot}) {
+      this.$router.push(`/project/${this.project.id}/image/${annot.image}/annotation/${annot.id}`);
     },
     async fetchImages() {
       if (!this.tooManyImages) {

--- a/src/components/annotations/ListAnnotationsBy.vue
+++ b/src/components/annotations/ListAnnotationsBy.vue
@@ -47,7 +47,7 @@
         @updateProperties="$emit('updateProperties')"
         @centerView="$emit('centerView', annot)"
         @deletion="$emit('delete', annot)"
-        @selectAnnotation="$emit('select', annot)"
+        @select="$emit('select', $event)"
       />
 
       <b-pagination

--- a/src/components/viewer/AnnotationDetailsContainer.vue
+++ b/src/components/viewer/AnnotationDetailsContainer.vue
@@ -51,7 +51,8 @@
         @updateTerms="$emit('updateTermsOrTracks', annot)"
         @updateTracks="$emit('updateTermsOrTracks', annot)"
         @updateProperties="$emit('updateProperties')"
-        @centerView="$emit('centerView', annot)"
+        @select="$emit('select', $event)"
+        @centerView="$emit('centerView', ($event) ? $event : annot)"
         @deletion="$emit('delete', annot)"
       />
     </div>
@@ -71,7 +72,6 @@ export default {
   components: {VueDraggableResizable, AnnotationDetails},
   props: {
     index: String,
-    view: Object
   },
   data() {
     return {

--- a/src/components/viewer/AnnotationLayer.vue
+++ b/src/components/viewer/AnnotationLayer.vue
@@ -113,9 +113,9 @@ export default {
     }
   },
   methods: {
-    clearFeatures() {
+    clearFeatures(cache=true) {
       if(this.$refs.olSource) {
-        this.$store.commit(this.imageModule + 'removeLayerFromSelectedFeatures', {layer: this.layer, cache: true});
+        this.$store.commit(this.imageModule + 'removeLayerFromSelectedFeatures', {layer: this.layer, cache});
         this.$refs.olSource.clearFeatures();
       }
     },
@@ -146,7 +146,7 @@ export default {
           this.clearFeatures();
         }
         else if(hard) {
-          this.clearFeatures();
+          this.clearFeatures(false);
           this.loader();
         }
         else {

--- a/src/components/viewer/AnnotationLayer.vue
+++ b/src/components/viewer/AnnotationLayer.vue
@@ -360,7 +360,7 @@ export default {
   },
   mounted() {
     this.$eventBus.$on('addAnnotation', this.addAnnotationHandler);
-    this.$eventBus.$on('selectAnnotation', this.selectAnnotationHandler);
+    this.$eventBus.$on('selectAnnotationInLayer', this.selectAnnotationHandler);
     this.$eventBus.$on('reloadAnnotations', this.reloadAnnotationsHandler);
     this.$eventBus.$on('reviewAnnotation', this.reviewAnnotationHandler);
     this.$eventBus.$on('editAnnotation', this.editAnnotationHandler);
@@ -369,7 +369,7 @@ export default {
   beforeDestroy() {
     // unsubscribe from all events
     this.$eventBus.$off('addAnnotation', this.addAnnotationHandler);
-    this.$eventBus.$off('selectAnnotation', this.selectAnnotationHandler);
+    this.$eventBus.$off('selectAnnotationInLayer', this.selectAnnotationHandler);
     this.$eventBus.$off('reloadAnnotations', this.reloadAnnotationsHandler);
     this.$eventBus.$off('reviewAnnotation', this.reviewAnnotationHandler);
     this.$eventBus.$off('editAnnotation', this.editAnnotationHandler);

--- a/src/components/viewer/AnnotationsContainer.vue
+++ b/src/components/viewer/AnnotationsContainer.vue
@@ -3,8 +3,8 @@
     <annotation-details-container
       v-if="isPanelDisplayed('annotation-main')"
       :index="index"
-      :view="view"
-      @centerView="centerViewOnAnnot"
+      @select="selectAnnotation({annot: $event})"
+      @centerView="centerView({annot: $event, sameView: true})"
       @addTerm="addTerm"
       @addTrack="addTrack"
       @updateTermsOrTracks="updateTermsOrTracks"
@@ -14,8 +14,8 @@
     <annotations-list
       class="annotations-table-wrapper"
       :index="index"
-      :view="view"
-      @centerView="centerViewOnAnnot"
+      @select="selectAnnotation"
+      @centerView="centerView"
       @addTerm="addTerm"
       @addTrack="addTrack"
       @updateTermsOrTracks="updateTermsOrTracks"
@@ -38,7 +38,6 @@ export default {
   name: 'AnnotationsContainer',
   props: {
     index: String,
-    view: Object
   },
   data() {
     return {
@@ -69,11 +68,6 @@ export default {
       return this.configUI[`project-explore-${panel}`];
     },
 
-    centerViewOnAnnot(annot) {
-      let geometry = this.format.readGeometry(annot.location);
-      this.view.fit(geometry, {duration: 500, padding: [10, 10, 10, 10], maxZoom: this.image.zoom});
-    },
-
     addTerm(term) {
       this.$store.dispatch(this.viewerModule + 'addTerm', term);
     },
@@ -99,6 +93,20 @@ export default {
       this.$store.commit(this.imageModule + 'addAction', {annot: annot, type: Action.DELETE});
       this.$eventBus.$emit('deleteAnnotation', annot);
     },
+
+    selectAnnotation({annot, sameView=false}) {
+      let index = (sameView) ? this.index : null;
+      this.$eventBus.$emit('selectAnnotation', {index, annot, center: true});
+    },
+
+    centerView({annot, sameView=false}) {
+      if (sameView) {
+        this.$emit('centerView', annot);
+      }
+      else {
+        this.$eventBus.$emit('selectAnnotation', {index: null, annot, center: true});
+      }
+    }
   }
 };
 </script>

--- a/src/components/viewer/AnnotationsContainer.vue
+++ b/src/components/viewer/AnnotationsContainer.vue
@@ -3,7 +3,7 @@
     <annotation-details-container
       v-if="isPanelDisplayed('annotation-main')"
       :index="index"
-      @select="selectAnnotation({annot: $event})"
+      @select="selectAnnotation"
       @centerView="centerView({annot: $event, sameView: true})"
       @addTerm="addTerm"
       @addTrack="addTrack"
@@ -94,8 +94,8 @@ export default {
       this.$eventBus.$emit('deleteAnnotation', annot);
     },
 
-    selectAnnotation({annot, sameView=false}) {
-      let index = (sameView) ? this.index : null;
+    selectAnnotation({annot, options}) {
+      let index = (options.trySameView) ? this.index : null;
       this.$eventBus.$emit('selectAnnotation', {index, annot, center: true});
     },
 

--- a/src/components/viewer/AnnotationsList.vue
+++ b/src/components/viewer/AnnotationsList.vue
@@ -63,9 +63,9 @@
 
           @updateTermsOrTracks="$emit('updateTermsOrTracks', $event)"
           @updateProperties="$emit('updateProperties')"
-          @centerView="$emit('centerView', $event)"
+          @centerView="$emit('centerView', {annot: $event, sameView: displayType === 'TERM'})"
           @delete="$emit('delete', $event)"
-          @select="select($event)"
+          @select="$emit('select', {annot: $event, sameView: displayType === 'TERM'})"
         />
       </div>
     </div>
@@ -103,7 +103,6 @@ export default {
   },
   props: [
     'index',
-    'view'
   ],
   data() {
     return {
@@ -258,19 +257,19 @@ export default {
         this.revision++;
       }
     },
-    async select(annot) {
-      if (annot.slice !== this.slice.id) {
-        await this.$store.dispatch(this.imageModule + 'setActiveSliceByPosition',
-          {time: annot.time, channel: annot.channel, zStack: annot.zStack});
-        this.$store.commit(this.imageModule + 'setAnnotToSelect', annot);
-        this.$eventBus.$emit('reloadAnnotations', {idImage: this.image.id, hard: true});
-      }
-      else {
-        this.$eventBus.$emit('selectAnnotation', {index: this.index, annot});
-      }
-
-      this.$emit('centerView', annot);
-    },
+    // async select(annot) {
+    //   if (annot.slice !== this.slice.id) {
+    //     //TODO
+    //     await this.$store.dispatch(this.imageModule + 'setActiveSliceByPosition',
+    //       {time: annot.time, channel: annot.channel, zStack: annot.zStack});
+    //     this.$store.commit(this.imageModule + 'setAnnotToSelect', annot);
+    //     this.$eventBus.$emit('reloadAnnotations', {idImage: this.image.id, hard: true});
+    //     this.$emit('centerView', annot);
+    //   }
+    //   else {
+    //     this.$eventBus.$emit('selectAnnotation', {index: this.index, annot, center: true});
+    //   }
+    // },
 
     shortkeyHandler(key) {
       if (!this.isActiveImage) {

--- a/src/components/viewer/AnnotationsList.vue
+++ b/src/components/viewer/AnnotationsList.vue
@@ -63,9 +63,9 @@
 
           @updateTermsOrTracks="$emit('updateTermsOrTracks', $event)"
           @updateProperties="$emit('updateProperties')"
-          @centerView="$emit('centerView', {annot: $event, sameView: displayType === 'TERM'})"
+          @centerView="$emit('centerView', {annot: $event, sameView: isSameView($event)})"
           @delete="$emit('delete', $event)"
-          @select="$emit('select', {annot: $event, sameView: displayType === 'TERM'})"
+          @select="select"
         />
       </div>
     </div>
@@ -256,6 +256,12 @@ export default {
       if(deletedAnnot.image === this.image.id) {
         this.revision++;
       }
+    },
+    isSameView(annot) {
+      return this.displayType === 'TERM' && annot.slice === this.slice.id;
+    },
+    select({annot, options}) {
+      this.$emit('select', {annot, options: {trySameView: options.trySameView || this.isSameView(annot)}});
     },
     // async select(annot) {
     //   if (annot.slice !== this.slice.id) {

--- a/src/components/viewer/CytomineViewer.vue
+++ b/src/components/viewer/CytomineViewer.vue
@@ -233,23 +233,34 @@ export default {
     },
 
     async selectAnnotationHandler({index, annot, center=false}) {
-      if (index === null) {
-        try {
+      try {
+        if (index && annot.image !== this.viewer.images[index].imageInstance.id) {
+          annot = await Annotation.fetch(annot.id);
+          let [image, slice] = await Promise.all([
+            ImageInstance.fetch(annot.image),
+            SliceInstance.fetch(annot.slice)
+          ]);
+          this.$store.commit(`${this.viewerModule}images/${index}/setRoutedAnnotation`, annot);
+          await this.$store.dispatch(`${this.viewerModule}images/${index}/setImageInstance`, {image, slice});
+        }
+        else if (index === null) {
           annot = await Annotation.fetch(annot.id);
           if (this.idImages.includes(String(annot.image))) {
             let index = this.cells.find(cell => cell.image.id === annot.image).index;
             this.$eventBus.$emit('selectAnnotation', {index, annot, center});
           }
           else {
-            let image = await ImageInstance.fetch(annot.image);
-            let slice = await SliceInstance.fetch(annot.slice);
+            let [image, slice] = await Promise.all([
+              ImageInstance.fetch(annot.image),
+              SliceInstance.fetch(annot.slice)
+            ]);
             await this.$store.dispatch(this.viewerModule + 'addImage', {image, slice, annot});
           }
         }
-        catch(err) {
-          console.log(err);
-          this.error = true;
-        }
+      }
+      catch(err) {
+        console.log(err);
+        this.error = true;
       }
     },
 

--- a/src/components/viewer/CytomineViewer.vue
+++ b/src/components/viewer/CytomineViewer.vue
@@ -235,17 +235,16 @@ export default {
     async selectAnnotationHandler({index, annot, center=false}) {
       if (index === null) {
         try {
-          let newImage = false;
           annot = await Annotation.fetch(annot.id);
-          if (!this.idImages.includes(String(annot.image))) {
+          if (this.idImages.includes(String(annot.image))) {
+            let index = this.cells.find(cell => cell.image.id === annot.image).index;
+            this.$eventBus.$emit('selectAnnotation', {index, annot, center});
+          }
+          else {
             let image = await ImageInstance.fetch(annot.image);
             let slice = await SliceInstance.fetch(annot.slice);
-            await this.$store.dispatch(this.viewerModule + 'addImage', {image, slice});
-            newImage = true;
+            await this.$store.dispatch(this.viewerModule + 'addImage', {image, slice, annot});
           }
-
-          let index = this.cells.find(cell => cell.image.id === annot.image).index;
-          this.$eventBus.$emit('selectAnnotation', {index, annot, center, newImage});
         }
         catch(err) {
           console.log(err);

--- a/src/components/viewer/CytomineViewer.vue
+++ b/src/components/viewer/CytomineViewer.vue
@@ -53,7 +53,7 @@ import viewerModuleModel from '@/store/modules/project_modules/viewer';
 import constants from '@/utils/constants.js';
 import shortcuts from '@/utils/shortcuts.js';
 
-import {ImageInstance, SliceInstance} from 'cytomine-client';
+import {ImageInstance, SliceInstance, Annotation} from 'cytomine-client';
 
 export default {
   name: 'cytomine-viewer',
@@ -232,6 +232,28 @@ export default {
       }
     },
 
+    async selectAnnotationHandler({index, annot, center=false}) {
+      if (index === null) {
+        try {
+          let newImage = false;
+          annot = await Annotation.fetch(annot.id);
+          if (!this.idImages.includes(String(annot.image))) {
+            let image = await ImageInstance.fetch(annot.image);
+            let slice = await SliceInstance.fetch(annot.slice);
+            await this.$store.dispatch(this.viewerModule + 'addImage', {image, slice});
+            newImage = true;
+          }
+
+          let index = this.cells.find(cell => cell.image.id === annot.image).index;
+          this.$eventBus.$emit('selectAnnotation', {index, annot, center, newImage});
+        }
+        catch(err) {
+          console.log(err);
+          this.error = true;
+        }
+      }
+    },
+
     shortkeyEvent(event) {
       this.$eventBus.$emit('shortkeyEvent', event.srcKey);
     }
@@ -244,7 +266,11 @@ export default {
       constants.VIEWER_ANNOTATIONS_REFRESH_INTERVAL
     );
   },
+  mounted() {
+    this.$eventBus.$on('selectAnnotation', this.selectAnnotationHandler);
+  },
   beforeDestroy() {
+    this.$eventBus.$off('selectAnnotation', this.selectAnnotationHandler);
     clearInterval(this.reloadInterval);
   }
 };

--- a/src/components/viewer/panels/LayersPanel.vue
+++ b/src/components/viewer/panels/LayersPanel.vue
@@ -170,6 +170,22 @@ export default {
           this.layers = this.layers.filter(layer => !layer.isReview);
         }
       }
+    },
+    layersToPreload: {
+      deep: true,
+      handler: function(layersToPreload) {
+        layersToPreload.forEach(layerId => {
+          let index = this.selectedLayersIds.findIndex(id => id === this.reviewLayer.id);
+          if(index !== -1) {
+            if (!this.selectedLayers[index].visible) {
+              this.toggleLayerVisibility(index);
+            }
+            return;
+          }
+
+          this.addLayerById(layerId, true);
+        });
+      }
     }
   },
   methods: {

--- a/src/store/modules/project_modules/viewer.js
+++ b/src/store/modules/project_modules/viewer.js
@@ -97,10 +97,13 @@ export default {
       router.replace(getters.pathViewer({idAnnotation, action}));
     },
 
-    async addImage({state, commit, getters, dispatch}, {image, slice}) {
+    async addImage({state, commit, getters, dispatch}, {image, slice, annot=null}) {
       let index = state.indexNextImage;
       commit('addImage');
       this.registerModule(getters.pathImageModule(index), imageModule);
+      if (annot) {
+        commit(`images/${index}/setRoutedAnnotation`, annot);
+      }
       await dispatch(`images/${index}/initialize`, {image, slice});
       dispatch('changePath');
     },

--- a/src/store/modules/project_modules/viewer_modules/image.js
+++ b/src/store/modules/project_modules/viewer_modules/image.js
@@ -56,7 +56,9 @@ export default {
       sliceInstances: {},
       loadedSlicePages: [],
       activeSlice: null,
-      activePanel: null
+      activePanel: null,
+
+      routedAnnotation: null
     };
   },
 
@@ -95,6 +97,13 @@ export default {
 
     setProfile(state, profile) {
       state.profile = profile;
+    },
+
+    setRoutedAnnotation(state, annotation) {
+      state.routedAnnotation = annotation;
+    },
+    clearRoutedAnnotation(state) {
+      state.routedAnnotation = null;
     }
   },
 


### PR DESCRIPTION
This is a hard one ! The PR refactors the way to programmatically select an annotation in the viewer, that is, select an annotation by other means than clicking on it in the viewer (which is handled by OpenLayers, and nothing changes on this side).

It has initally been implemented with Annotation links in mind. While this feature is experimental (and not included here then), the new programmatic selection implies some logic modifications at many places that would be great to integrate to help ULiege to stay synchronized with main repository. The good news it that the refactoring also unleashes many new features that could be helpful in other contexts !

It uses an event bus `selectAnnotation` that takes up to 4 parameters:
* `index`: the viewer index where the annotation has to be selected
* `annot`: the Cytomine annotation object
* `center`: boolean, whether the viewer has to be centered on the annotation or not (default false)
* `showComments`: boolean, whether to open the comments modal or not (default false)

It means you can select (and center on) an annotation **in any viewer** from **everywhere** in a `CytomineViewer` (collection of viewers = collection of `CytomineImage`). There are several cases:
If index is set, it changes the image to the image associated to the annotation in the viewer if needed and adapt the slice if needed
If index is not set (null), it tries to find a viewer with the image associated to the annotation and adapt the slice if needed. If the image is not yet opened, it adds a viewer and open it at the right image and slice.

The center feature needed particular attention as it requires that the OpenLayer view is mounted, but this is transparently managed by the `selectAnnotation` handler, in all cases.

In all cases, it transparently adds and make visible the annotation layer of the selected annotation.

This new implementation takes also the responsibility of selecting annotation passed into parameter in the URL.

It has been tested and used in production for more than 1 year on ULiege edition.