### PR TITLE
Fix image download button

### DIFF
--- a/src/components/image/ImageDetails.vue
+++ b/src/components/image/ImageDetails.vue
@@ -327,14 +327,15 @@ export default {
   computed: {
     currentUser: get('currentUser/user'),
     configUI: get('currentProject/configUI'),
+    project: get('currentProject/project'),
     blindMode() {
-      return ((this.$store.state.currentProject.project || {}).blindMode) || false;
+      return ((this.project || {}).blindMode) || false;
     },
     canDownloadImages() {
       // Virtual images (null path) cannot be downloaded.
       return this.image.path !== null && (
         this.canManageProject ||
-        ((this.$store.state.currentProject.project || {}).areImagesDownloadable) || false
+        ((this.project || {}).areImagesDownloadable) || false
       );
     },
     canManageProject() {
@@ -405,7 +406,7 @@ export default {
         });
         this.$emit('delete');
 
-        let updatedProject = this.$store.state.currentProject.project.clone();
+        let updatedProject = this.project.clone();
         updatedProject.numberOfImages--;
         this.$store.dispatch('currentProject/updateProject', updatedProject);
       }

--- a/src/components/image/ImageDetails.vue
+++ b/src/components/image/ImageDetails.vue
@@ -239,7 +239,7 @@
                 {{$t('button-set-magnification')}}
               </button>
             </template>
-            <a class="button" v-if="canDownloadImages || canManageProject" :href="image.downloadURL">
+            <a class="button" v-if="canDownloadImages" :href="image.downloadURL">
               {{$t('button-download')}}
             </a>
             <template v-if="canEdit">
@@ -331,7 +331,11 @@ export default {
       return ((this.$store.state.currentProject.project || {}).blindMode) || false;
     },
     canDownloadImages() {
-      return ((this.$store.state.currentProject.project || {}).areImagesDownloadable) || false;
+      // Virtual images (null path) cannot be downloaded.
+      return this.image.path !== null && (
+        this.canManageProject ||
+        ((this.$store.state.currentProject.project || {}).areImagesDownloadable) || false
+      );
     },
     canManageProject() {
       return this.$store.getters['currentProject/canManageProject'];

--- a/src/components/viewer/panels/InformationPanel.vue
+++ b/src/components/viewer/panels/InformationPanel.vue
@@ -76,7 +76,7 @@
             <router-link :to="`/project/${image.project}/image/${image.id}/information`" class="button is-small">
               {{$t('button-more-info')}}
             </router-link>
-            <a class="button is-small" :href="image.downloadURL">
+            <a class="button is-small" v-if="canDownloadImages" :href="image.downloadURL">
               {{$t('button-download')}}
             </a>
           </div>
@@ -142,6 +142,16 @@ export default {
     },
     canEdit() {
       return this.$store.getters['currentProject/canEditImage'](this.image);
+    },
+    canDownloadImages() {
+      // Virtual images (null path) cannot be downloaded.
+      return this.image.path !== null && (
+        this.canManageProject ||
+        ((this.$store.state.currentProject.project || {}).areImagesDownloadable) || false
+      );
+    },
+    canManageProject() {
+      return this.$store.getters['currentProject/canManageProject'];
     },
     isActiveImage() {
       return this.viewerWrapper.activeImage === this.index;


### PR DESCRIPTION
The PR updates the logic to display the Download image button or not.
The download button is displayed:
* if the image is not virtual (**new**) AND
* if the project configuration allows image download OR if the current user is project manager (**as before**)

Code is a bit refactored to take advantage of the utility `get` function.

Also, the logic is also applied to the Download button in the Information panel. There was an issue, as the logic was not implemented here and the button always shown.