### PR TITLE
feat: add reviewed annotation status

### DIFF
--- a/src/components/annotations/AnnotationDetails.vue
+++ b/src/components/annotations/AnnotationDetails.vue
@@ -158,10 +158,16 @@
             {{ creator.fullName }}
           </td>
         </tr>
-        <tr v-if="!isReview">
-          <td><strong>{{$t('created-on')}}</strong></td>
-          <td> {{ Number(annotation.created) | moment('ll') }} </td>
-        </tr>
+        <template v-if="!isReviewedAnnotation">
+          <tr>
+            <td><strong>{{ $t('created-on') }}</strong></td>
+              <td> {{ Number(annotation.created) | moment('ll') }} </td>
+          </tr>
+          <tr v-if="isImageInReviewMode">
+            <td><strong>{{ $t('reviewed-annotation-status') }}</strong></td>
+            <td> {{ $t('reviewed-annotation-status-rejected') }} </td>
+          </tr>
+        </template>
         <template v-else>
           <tr>
             <td><strong>{{$t('reviewed-by')}}</strong></td>
@@ -172,6 +178,10 @@
           <tr>
             <td><strong>{{$t('reviewed-on')}}</strong></td>
             <td> {{ Number(annotation.created) | moment('ll') }} </td>
+          </tr>
+          <tr v-if="isImageInReviewMode">
+            <td><strong>{{ $t('reviewed-annotation-status') }}</strong></td>
+            <td> {{ $t('reviewed-annotation-status-validated') }} </td>
           </tr>
         </template>
       </template>
@@ -284,11 +294,11 @@ export default {
     creator() {
       return this.users.find(user => user.id === this.annotation.user) || {};
     },
-    isReview() {
+    isReviewedAnnotation() {
       return this.annotation.type === AnnotationType.REVIEWED;
     },
     reviewer() {
-      if(this.isReview) {
+      if(this.isReviewedAnnotation) {
         return this.users.find(user => user.id === this.annotation.reviewUser) || {};
       }
       return null;
@@ -304,6 +314,9 @@ export default {
     image() {
       return this.images.find(image => image.id === this.annotation.image) ||
         {'id': this.annotation.image, 'instanceFilename': this.annotation.instanceFilename};
+    },
+    isImageInReviewMode() {
+      return this.image.inReview;
     },
     sliceChannel() {
       return this.slices.find(slice => slice.id === this.annotation.slice) || {};

--- a/src/components/annotations/AnnotationDetails.vue
+++ b/src/components/annotations/AnnotationDetails.vue
@@ -165,7 +165,11 @@
           </tr>
           <tr v-if="isImageInReviewMode">
             <td><strong>{{ $t('reviewed-annotation-status') }}</strong></td>
-            <td> {{ $t('reviewed-annotation-status-rejected') }} </td>
+            <td> 
+              <span class="tag is-danger">
+                {{ $t('reviewed-annotation-status-not-validated') }}
+              </span>  
+            </td>
           </tr>
         </template>
         <template v-else>
@@ -181,7 +185,11 @@
           </tr>
           <tr v-if="isImageInReviewMode">
             <td><strong>{{ $t('reviewed-annotation-status') }}</strong></td>
-            <td> {{ $t('reviewed-annotation-status-validated') }} </td>
+            <td>
+              <span class="tag is-success">
+                {{ $t('reviewed-annotation-status-validated') }}
+              </span>
+            </td>
           </tr>
         </template>
       </template>

--- a/src/components/annotations/AnnotationDetails.vue
+++ b/src/components/annotations/AnnotationDetails.vue
@@ -568,11 +568,17 @@ a.is-fullwidth {
   margin-top: 4px;
 }
 
->>> .sl-vue-tree-node-item {
+/**
+* https://stackoverflow.com/a/55368933
+* Since the project is using Sass and Vue 2.6.10, use `::v-deep` instead of `>>>` so it doesn't break validation.
+* Note that it's deprecated but will in Vue 3.
+* TODO: update >>> and ::v-deep using the unified :deep() selector when using the latest Vue.
+*/
+::v-deep .sl-vue-tree-node-item {
   font-size: 0.9em;
 }
 
->>> .tag {
+::v-deep .tag {
     margin-right: 5px;
     margin-bottom: 5px !important;
     background-color: rgba(0, 0, 0, 0.04);

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -744,9 +744,9 @@ reviewers,Reviewers,Validateurs,Revisores
 review-layer,Review layer,Calque de validation,Capa de revisión
 reviewed-by,Reviewed by,Validé par,Revisado por
 reviewed-on,Reviewed on,Validé le,Revisado el
-reviewed-annotation-status,Status,Statut,Estado
+reviewed-annotation-status,Review Status,Statut de la révision,Estado de revisión
 reviewed-annotation-status-validated,Validated,Validé,Validado
-reviewed-annotation-status-rejected,Rejected,Rejeté,Rechazado
+reviewed-annotation-status-not-validated,Not validated,Non validé,No validado
 button-metadata,Metadata,Métadonnées,Metadatos
 image-metadata,Image metadata,Métadonnées de l'image,Metadatos de imagen
 registration-date,Registration date,Date d'inscription,Fecha de registro

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -744,6 +744,9 @@ reviewers,Reviewers,Validateurs,Revisores
 review-layer,Review layer,Calque de validation,Capa de revisión
 reviewed-by,Reviewed by,Validé par,Revisado por
 reviewed-on,Reviewed on,Validé le,Revisado el
+reviewed-annotation-status,Status,Statut,Estado
+reviewed-annotation-status-validated,Validated,Validé,Validado
+reviewed-annotation-status-rejected,Rejected,Rejeté,Rechazado
 button-metadata,Metadata,Métadonnées,Metadatos
 image-metadata,Image metadata,Métadonnées de l'image,Metadatos de imagen
 registration-date,Registration date,Date d'inscription,Fecha de registro


### PR DESCRIPTION
This is current solution for showing the state of an annotation.
I think there are still multiple issues with the current system (see reference ticket).

Since I was working in this component, I also updated the deep selector to a "sass compatible" version (`>>>` to `::v-deep`)

https://gitlab.cytom.in/cm/rnd/issue_triage/-/issues/469