### PR TITLE
feat: add no category option

### DIFF
--- a/src/components/annotations/AnnotationPreview.vue
+++ b/src/components/annotations/AnnotationPreview.vue
@@ -118,7 +118,7 @@ export default {
     },
     styleAnnotDetails() {
       let url = appendShortTermToken(`${this.cropUrl}`, this.shortTermToken);
-      console.log('url', url);
+      //console.log('url', url);
       return {
         backgroundImage: `url(${url})`,
         backgroundRepeat: 'no-repeat',

--- a/src/components/annotations/ListAnnotationsBy.vue
+++ b/src/components/annotations/ListAnnotationsBy.vue
@@ -137,6 +137,9 @@ export default {
     isByTag() {
       return this.categorization === 'TAG';
     },
+    isUncategorized() {
+      return this.categorization === 'UNCATEGORIZED';
+    },
     filteredTermsIds() {
       return this.termsIds.filter(id => id > 0);
     },
@@ -206,6 +209,9 @@ export default {
       }
       else if (this.isByTag && this.noTag) {
         return this.$t('no-tag');
+      }
+      else if (this.isUncategorized) {
+        return this.$t('all-annotations-uncategorized');
       }
       else {
         return this.prop.name;
@@ -361,11 +367,14 @@ export default {
   color: grey;
 }
 
->>> ul.pagination-list {
+/**
+ * TODO: use :deep(.class) when moving to Vue3
+ */
+::v-deep ul.pagination-list {
   justify-content: flex-end;
 }
 
->>> .active .annot-preview {
+::v-deep .active .annot-preview {
   box-shadow: 0 2px 3px rgba(39, 120, 173, 0.75), 0 0 0 1px rgba(39, 120, 173, 0.75);
   font-weight: 600;
 }

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -1026,7 +1026,8 @@ per-term,Per term,Par terme,
 per-track,Per track,Par trace,
 per-user,Per user,Par utilisateur,
 per-image,Per image,Par image,
-categorization,Categorization,Catégorisation,
+uncategorized,Uncategorized,Non classé,Sin categoría
+categorization,Categorization,Catégorisation,Categorización
 currently-visible-annotations-with,Currently visible annotations with,Annotations actuellement visibles avec,
 currently-visible-annotations-for-track,Currently visible annotations for track,Annotations actuellement visibles pour la trace,
 the-term,term,le terme,
@@ -1064,3 +1065,4 @@ followers,Followers,Suiveurs
 button-adjust,Adjust,Ajuster
 button-adjust-slice,Adjust slice,Ajuster l'image
 button-adjust-image,Adjust image,Ajuster le plan
+all-annotations-uncategorized,All annotations uncategorized,Toutes les annotations non classées,Todas las anotaciones sin categorizar


### PR DESCRIPTION
This is currently what I've modified to add this option.
It seems to work but as mentioned in our call, it's hard to cover every combinations.

In the end, I called the option "Uncategorized" in English.
If the preference is really "No Categorization", it's an easy update.

It would be nice if @gvincke and @waliens could test it as well in different scenarios (some I may not have considered).